### PR TITLE
update for Julia 0.7, drop older version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false
@@ -28,8 +29,8 @@ git:
 ## uncomment the following lines to override the default test script
 #script:
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("JuliaRunClient"); Pkg.test("JuliaRunClient"; coverage=true)'
-after_success:
-  # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("JuliaRunClient")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("JuliaRunClient")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+#after_success:
+#  # push coverage results to Coveralls
+#  - julia -e 'cd(Pkg.dir("JuliaRunClient")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+#  # push coverage results to Codecov
+#  - julia -e 'cd(Pkg.dir("JuliaRunClient")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,4 @@
-julia 0.5
-Compat
-Requests
-HttpCommon
+julia 0.7
+HTTP
 JSON
 ClusterManagers

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
+# test just package loading as of now
 using JuliaRunClient
-using Base.Test
+#using Test
 
 # write your own tests here
-@test 1 == 2
+#@test 1 == 2


### PR DESCRIPTION
- update for Julia 0.7, drop older version support
- drop Compat.jl
- use HTTP.jl instead of Requests.jl